### PR TITLE
EventType should be the underlying payload type

### DIFF
--- a/src/Akka.Persistence.EventStore/Journal/EventStoreJournal.cs
+++ b/src/Akka.Persistence.EventStore/Journal/EventStoreJournal.cs
@@ -113,7 +113,7 @@ namespace Akka.Persistence.EventStore.Journal
                     var eventId = GuidUtility.Create(GuidUtility.IsoOidNamespace, string.Concat(stream, x.SequenceNr));
 
                     var meta = new byte[0];
-                    return new EventData(eventId, x.GetType().FullName, true, data, meta);
+                    return new EventData(eventId, x.Payload.GetType().FullName, true, data, meta);
                 });
 
                 await connection.AppendToStreamAsync(stream, expectedVersion < 0 ? ExpectedVersion.NoStream : expectedVersion, events);


### PR DESCRIPTION
Hey,

Tiny one, but seems like the payload should be the EventType presented to the EventStore. Makes viewing the stream in the web ui a lot easier.

Cheers